### PR TITLE
Include $SPARQL_ENDPOINT from env as an option in the demo dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Graph Explorer is a fork of [Ontodia](https://github.com/metaphacts/ontodia), no
 
 `npm run demo` and open <http://localhost:10444/>
 
+or
+
+`SPARQL_ENDPOINT=http://localhost:7200/repositories/foobar npm run demo` and open <http://localhost:10444/envendpoint.html>
+
 ## Installation
 
 `npm install graph-explorer`

--- a/examples/envendpoint.ts
+++ b/examples/envendpoint.ts
@@ -1,0 +1,67 @@
+import { createElement, ClassAttributes } from 'react';
+import * as ReactDOM from 'react-dom';
+
+import {
+  Workspace,
+  WorkspaceProps,
+  SparqlDataProvider,
+  SparqlQueryMethod,
+  OWLRDFSSettings,
+} from '../src/graph-explorer/index';
+
+import {
+  onPageLoad,
+  tryLoadLayoutFromLocalStorage,
+  saveLayoutToLocalStorage,
+} from './common';
+
+function onWorkspaceMounted(workspace: Workspace) {
+  if (!workspace) {
+    return;
+  }
+
+  const diagram = tryLoadLayoutFromLocalStorage();
+  workspace.getModel().importLayout({
+    diagram,
+    validateLinks: true,
+    dataProvider: new SparqlDataProvider(
+      {
+
+        // this goes to process.env.SPARQL_ENDPOINT via devServer proxy rule in webpack.demo.config.js
+        endpointUrl: '../sparql',
+        
+        imagePropertyUris: [
+          'http://xmlns.com/foaf/0.1/depiction',
+          'http://xmlns.com/foaf/0.1/img',
+        ],
+        queryMethod: SparqlQueryMethod.GET,
+      },
+      {...OWLRDFSSettings,
+      ...{
+        classTreeQuery: `        
+          SELECT distinct ?class ?label ?parent WHERE {
+            ?class a owl:Class.
+            OPTIONAL {?class rdfs:label ?label.}
+            OPTIONAL {?class rdfs:subClassOf ?parent}
+          }`
+        }
+      }
+    ),
+  });
+}
+
+const props: WorkspaceProps & ClassAttributes<Workspace> = {
+  ref: onWorkspaceMounted,
+  onSaveDiagram: (workspace) => {
+    const diagram = workspace.getModel().exportLayout();
+    window.location.hash = saveLayoutToLocalStorage(diagram);
+    window.location.reload();
+  },
+  viewOptions: {
+    onIriClick: ({ iri }) => window.open(iri),
+  },
+};
+
+onPageLoad((container) => {
+  ReactDOM.render(createElement(Workspace, props), container);
+});

--- a/examples/template.ejs
+++ b/examples/template.ejs
@@ -30,6 +30,7 @@
             <option value="wikidataGraph.html">WikidataGraph</option>
             <option value="composite.html">Composite</option>
             <option value="toolbarCustomization.html">Toolbar customization</option>
+            <option value="envendpoint.html">On $SPARQL_ENDPOINT</option>
         </select>
         <script>
             var pathname = window.location.pathname;

--- a/webpack.demo.config.js
+++ b/webpack.demo.config.js
@@ -33,6 +33,7 @@ module.exports = {
     composite: path.join(examplesDir, 'composite.ts'),
     wikidataGraph: path.join(examplesDir, 'wikidataGraph.ts'),
     toolbarCustomization: path.join(examplesDir, 'toolbarCustomization.tsx'),
+    envendpoint: path.join(examplesDir, 'envendpoint.ts'),
   },
   resolve: {
     alias: aliases,
@@ -109,6 +110,12 @@ module.exports = {
       filename: 'toolbarCustomization.html',
       title: 'Graph Explorer Toolbar Customization Demo',
       chunks: ['commons', 'toolbarCustomization'],
+      template: htmlTemplatePath,
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'envendpoint.html',
+      title: 'Graph Explorer on $SPARQL_ENDPOINT from env',
+      chunks: ['commons', 'envendpoint'],
       template: htmlTemplatePath,
     }),
   ],


### PR DESCRIPTION
This change adds an option to the demo dropdown list, so that `$SPARQL_ENDPOINT` from the environment can be selected as the datasource for graph-explorer.

![image](https://github.com/zazuko/graph-explorer/assets/877232/dd15ab11-db44-4b78-a8e4-98b3ddba1925)


`SPARQL_ENDPOINT=http://localhost:7200/repositories/foobar npm run demo` and open <http://localhost:10444/envendpoint.html>